### PR TITLE
Added paragraph to explain that EducateWorkforce documentation uses Open edX platform documentation.

### DIFF
--- a/en_us/open_edx_course_authors/source/index.rst
+++ b/en_us/open_edx_course_authors/source/index.rst
@@ -4,6 +4,10 @@
 Building and Running an Open edX Course
 ########################################
 
+The following EducateWorkforce documentation is provided by the Open edX team from `docs.edx.org`_. The Open edX platform
+is the main web application that EducateWorkforce uses to serve course content. Should you have any questions or concerns
+about this documentation please use the feedback document at the top of this document to submit a request to the support team.
+
 .. toctree::
    :numbered:
    :maxdepth: 2
@@ -27,3 +31,5 @@ Building and Running an Open edX Course
    student_progress/index
    rerun_course/index
    glossary
+
+.. include:: ../../links/links.rst

--- a/en_us/open_edx_students/source/index.rst
+++ b/en_us/open_edx_students/source/index.rst
@@ -4,6 +4,10 @@
 Open edX Learner's Guide
 ########################
 
+The following EducateWorkforce documentation is provided by the Open edX team from `docs.edx.org`_. The Open edX platform
+is the main web application that EducateWorkforce uses to serve course content. Should you have any questions or concerns
+about this documentation please use the feedback document at the top of this document to submit a request to the support team.
+
 .. toctree::
    :numbered:
    :maxdepth: 2
@@ -31,3 +35,5 @@ Open edX Learner's Guide
    SFD_licensing
    sfd_troubleshooting/index
    front_matter/index
+
+.. include:: ../../links/links.rst


### PR DESCRIPTION
Applied to the following documents:
- Open edX Learner's Guide
- Building and Running an Open edX Course